### PR TITLE
Destroy Items In Lava, Fix Flag Duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added a developer panel to debug incoming and outgoing messages
 - Fixed chests being drawn under slime holes when they're pushed on top of one
 - Fixed a server crash and an unwanted game-over caused by a bug in the compiler modules
+- Fixed flag duplication bug
+- Fixed chest not being usable when placed on a slab
+- Items, which are submerged in lava after the slab they are resting on has sunken, are now destroyed
 - Changed the sound file format to OGG, which massively reduces the file size of the game
 - Reduced the network traffic by (x7) by not sending some unnecessary messages
 

--- a/server/entity.jai
+++ b/server/entity.jai
@@ -942,7 +942,7 @@ try_to_place_item :: (server: *Server, target_position: v2i, kind: Item_Kind, ta
         if guy.state == .Idle {
             put_item_in_hand(server, guy, kind);
             success = true;
-        } else {
+        } else if kind == .Flag {
             place_flag_on_ground();
             success = true;
         }

--- a/server/entity.jai
+++ b/server/entity.jai
@@ -579,8 +579,20 @@ update_slab :: (server: *Server, slab: *Slab) {
     slab.time_left_in_seconds -= server.tick_time;
 
     if slab.time_left_in_seconds <= 0 {
+        lava_position := slab.physical_position;
+        
         remove_entity(server, slab);
-        create_entity(server, .Lava, slab.physical_position, .North);
+        create_entity(server, .Lava, lava_position, .North);
+        
+        // Remove non-living entities which have fallen in lava
+        for i := 0; i < server.all_entities.slot_count; ++i {
+            entity, occupied := index_bucket_array(*server.all_entities, i);
+            if !occupied || entity.marked_for_removal || (entity.entity_flags & .Disabled_Temporarily) continue;
+            if entity.physical_position.x != lava_position.x || entity.physical_position.y != lava_position.y continue;
+            if entity.entity_kind == .Lava || entity.entity_kind == .Flag || (entity.entity_flags & .Living) continue;
+            
+            remove_entity(server, entity);
+        }
     }
 }
 

--- a/server/server.jai
+++ b/server/server.jai
@@ -949,8 +949,9 @@ handle_guy_input :: (server: *Server, guy: *Guy) {
                     switch_guy_state(server, guy, .Idle);
                     create_entity(server, .Torch, guy.target_position, .North);
                 }
-            } else if !target_entity && guy.carrying_item == .Chest {
-                if position_in_bounds(server, guy.target_position) {
+            } else if guy.carrying_item == .Chest {
+                chest_is_placeable := (!target_entity || target_entity.entity_kind == .Slab);
+                if position_in_bounds(server, guy.target_position) && chest_is_placeable {
                     switch_guy_state(server, guy, .Idle);
                     chest_entity := create_entity(server, .Chest, guy.target_position, .North);
                     chest := down(chest_entity, Chest);

--- a/shared/VERSION_STRING.jai
+++ b/shared/VERSION_STRING.jai
@@ -1,1 +1,1 @@
-VERSION_STRING :: "7ffba97"; 
+VERSION_STRING :: "e761f77";


### PR DESCRIPTION
 - Items which have fallen into lava after slab has submerged are destroyed (items such as coal & shards, mirrors, chests)
 - Fix flag duplication (guy A already holds an item, and guy B is trying to give guy A another non-flag item, a flag will be created on guy A)
 - Chests can be properly placed on slabs (but will be destroyed once the slab disappears)